### PR TITLE
Add cargo crate 'async trait' as depenency

### DIFF
--- a/library/crates/BUILD.bazel
+++ b/library/crates/BUILD.bazel
@@ -22,6 +22,15 @@ alias(
 )
 
 alias(
+    name = "async_trait",
+    actual = "@raze__async_trait__0_1_59//:async_trait",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
     name = "axum",
     actual = "@raze__axum__0_5_15//:axum",
     tags = [

--- a/library/crates/Cargo.toml
+++ b/library/crates/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "=1.20.1", features = ["rt", "rt-multi-thread"] }
 tonic = "=0.8.0"
 tonic-build = "=0.8.0"
 uuid = { version = "=1.1.2", features = ["fast-rng", "v4"] }
+async-trait = "0.1.59"
 
 [package.metadata.raze]
 # The path at which to write output files.

--- a/library/crates/crates.bzl
+++ b/library/crates/crates.bzl
@@ -88,12 +88,11 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "raze__async_trait__0_1_57",
-        url = "https://crates.io/api/v1/crates/async-trait/0.1.57/download",
+        name = "raze__async_trait__0_1_59",
+        url = "https://crates.io/api/v1/crates/async-trait/0.1.59/download",
         type = "tar.gz",
-        sha256 = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f",
-        strip_prefix = "async-trait-0.1.57",
-        build_file = Label("//library/crates/remote:BUILD.async-trait-0.1.57.bazel"),
+        strip_prefix = "async-trait-0.1.59",
+        build_file = Label("//library/crates/remote:BUILD.async-trait-0.1.59.bazel"),
     )
 
     maybe(
@@ -471,11 +470,11 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "raze__cxx_build__1_0_82",
-        url = "https://crates.io/api/v1/crates/cxx-build/1.0.82/download",
+        name = "raze__cxx_build__1_0_83",
+        url = "https://crates.io/api/v1/crates/cxx-build/1.0.83/download",
         type = "tar.gz",
-        strip_prefix = "cxx-build-1.0.82",
-        build_file = Label("//library/crates/remote:BUILD.cxx-build-1.0.82.bazel"),
+        strip_prefix = "cxx-build-1.0.83",
+        build_file = Label("//library/crates/remote:BUILD.cxx-build-1.0.83.bazel"),
     )
 
     maybe(
@@ -2289,11 +2288,11 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "raze__typenum__1_15_0",
-        url = "https://crates.io/api/v1/crates/typenum/1.15.0/download",
+        name = "raze__typenum__1_16_0",
+        url = "https://crates.io/api/v1/crates/typenum/1.16.0/download",
         type = "tar.gz",
-        strip_prefix = "typenum-1.15.0",
-        build_file = Label("//library/crates/remote:BUILD.typenum-1.15.0.bazel"),
+        strip_prefix = "typenum-1.16.0",
+        build_file = Label("//library/crates/remote:BUILD.typenum-1.16.0.bazel"),
     )
 
     maybe(

--- a/library/crates/remote/BUILD.async-trait-0.1.59.bazel
+++ b/library/crates/remote/BUILD.async-trait-0.1.59.bazel
@@ -52,7 +52,7 @@ cargo_build_script(
         "cargo-raze",
         "manual",
     ],
-    version = "0.1.57",
+    version = "0.1.59",
     visibility = ["//visibility:private"],
     deps = [
     ],
@@ -72,7 +72,7 @@ rust_proc_macro(
         "crate-name=async-trait",
         "manual",
     ],
-    version = "0.1.57",
+    version = "0.1.59",
     # buildifier: leave-alone
     deps = [
         ":async_trait_build_script",

--- a/library/crates/remote/BUILD.axum-0.5.15.bazel
+++ b/library/crates/remote/BUILD.axum-0.5.15.bazel
@@ -58,7 +58,7 @@ rust_library(
     compile_data = glob(["**/*.md"]),
     edition = "2021",
     proc_macro_deps = [
-        "@raze__async_trait__0_1_57//:async_trait",
+        "@raze__async_trait__0_1_59//:async_trait",
     ],
     rustc_flags = [
         "--cap-lints=allow",

--- a/library/crates/remote/BUILD.axum-core-0.2.7.bazel
+++ b/library/crates/remote/BUILD.axum-core-0.2.7.bazel
@@ -38,7 +38,7 @@ rust_library(
     data = [],
     edition = "2021",
     proc_macro_deps = [
-        "@raze__async_trait__0_1_57//:async_trait",
+        "@raze__async_trait__0_1_59//:async_trait",
     ],
     rustc_flags = [
         "--cap-lints=allow",

--- a/library/crates/remote/BUILD.crypto-common-0.1.6.bazel
+++ b/library/crates/remote/BUILD.crypto-common-0.1.6.bazel
@@ -52,6 +52,6 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         "@raze__generic_array__0_14_6//:generic_array",
-        "@raze__typenum__1_15_0//:typenum",
+        "@raze__typenum__1_16_0//:typenum",
     ],
 )

--- a/library/crates/remote/BUILD.cucumber-0.15.2.bazel
+++ b/library/crates/remote/BUILD.cucumber-0.15.2.bazel
@@ -43,7 +43,7 @@ rust_library(
     compile_data = glob(["**/*.md"]),
     edition = "2021",
     proc_macro_deps = [
-        "@raze__async_trait__0_1_57//:async_trait",
+        "@raze__async_trait__0_1_59//:async_trait",
         "@raze__cucumber_codegen__0_15_3//:cucumber_codegen",
         "@raze__derive_more__0_99_17//:derive_more",
         "@raze__sealed__0_4_0//:sealed",

--- a/library/crates/remote/BUILD.cxx-build-1.0.83.bazel
+++ b/library/crates/remote/BUILD.cxx-build-1.0.83.bazel
@@ -30,36 +30,9 @@ licenses([
 ])
 
 # Generated Targets
-# buildifier: disable=out-of-order-load
-# buildifier: disable=load-on-top
-load(
-    "@rules_rust//cargo:cargo_build_script.bzl",
-    "cargo_build_script",
-)
-
-cargo_build_script(
-    name = "typenum_build_script",
-    srcs = glob(["**/*.rs"]),
-    build_script_env = {
-    },
-    crate_root = "build/main.rs",
-    data = glob(["**"]),
-    edition = "2018",
-    rustc_flags = [
-        "--cap-lints=allow",
-    ],
-    tags = [
-        "cargo-raze",
-        "manual",
-    ],
-    version = "1.15.0",
-    visibility = ["//visibility:private"],
-    deps = [
-    ],
-)
 
 rust_library(
-    name = "typenum",
+    name = "cxx_build",
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
     data = [],
@@ -69,14 +42,18 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=typenum",
+        "crate-name=cxx-build",
         "manual",
     ],
-    version = "1.15.0",
+    version = "1.0.83",
     # buildifier: leave-alone
     deps = [
-        ":typenum_build_script",
+        "@raze__cc__1_0_73//:cc",
+        "@raze__codespan_reporting__0_11_1//:codespan_reporting",
+        "@raze__once_cell__1_13_1//:once_cell",
+        "@raze__proc_macro2__1_0_43//:proc_macro2",
+        "@raze__quote__1_0_21//:quote",
+        "@raze__scratch__1_0_2//:scratch",
+        "@raze__syn__1_0_99//:syn",
     ],
 )
-
-# Unsupported target "test" with type "test" omitted

--- a/library/crates/remote/BUILD.generic-array-0.14.6.bazel
+++ b/library/crates/remote/BUILD.generic-array-0.14.6.bazel
@@ -83,6 +83,6 @@ rust_library(
     # buildifier: leave-alone
     deps = [
         ":generic_array_build_script",
-        "@raze__typenum__1_15_0//:typenum",
+        "@raze__typenum__1_16_0//:typenum",
     ],
 )

--- a/library/crates/remote/BUILD.iana-time-zone-haiku-0.1.1.bazel
+++ b/library/crates/remote/BUILD.iana-time-zone-haiku-0.1.1.bazel
@@ -55,7 +55,7 @@ cargo_build_script(
     version = "0.1.1",
     visibility = ["//visibility:private"],
     deps = [
-        "@raze__cxx_build__1_0_82//:cxx_build",
+        "@raze__cxx_build__1_0_83//:cxx_build",
     ],
 )
 

--- a/library/crates/remote/BUILD.tonic-0.8.0.bazel
+++ b/library/crates/remote/BUILD.tonic-0.8.0.bazel
@@ -61,7 +61,7 @@ rust_library(
     compile_data = glob(["**/*.md"]),
     edition = "2018",
     proc_macro_deps = [
-        "@raze__async_trait__0_1_57//:async_trait",
+        "@raze__async_trait__0_1_59//:async_trait",
         "@raze__prost_derive__0_11_0//:prost_derive",
     ],
     rustc_flags = [

--- a/library/crates/remote/BUILD.typenum-1.16.0.bazel
+++ b/library/crates/remote/BUILD.typenum-1.16.0.bazel
@@ -30,9 +30,36 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "typenum_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_root = "build/main.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "1.16.0",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
 
 rust_library(
-    name = "cxx_build",
+    name = "typenum",
     srcs = glob(["**/*.rs"]),
     crate_root = "src/lib.rs",
     data = [],
@@ -42,18 +69,14 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=cxx-build",
+        "crate-name=typenum",
         "manual",
     ],
-    version = "1.0.82",
+    version = "1.16.0",
     # buildifier: leave-alone
     deps = [
-        "@raze__cc__1_0_73//:cc",
-        "@raze__codespan_reporting__0_11_1//:codespan_reporting",
-        "@raze__once_cell__1_13_1//:once_cell",
-        "@raze__proc_macro2__1_0_43//:proc_macro2",
-        "@raze__quote__1_0_21//:quote",
-        "@raze__scratch__1_0_2//:scratch",
-        "@raze__syn__1_0_99//:syn",
+        ":typenum_build_script",
     ],
 )
+
+# Unsupported target "test" with type "test" omitted


### PR DESCRIPTION
The cargo crate `async-trait` has been added as a rust dependency.